### PR TITLE
fix *significant* typo Inster -> Insert

### DIFF
--- a/src/service/ap_airplay_service.cpp
+++ b/src/service/ap_airplay_service.cpp
@@ -857,7 +857,7 @@ void ap_airplay_connection::post_action_handler(const request &req, response &re
     }
 
     res.with_content_type(TEXT_APPLE_PLIST_XML).with_content(ERROR_STATUS_RESPONSE);
-  } else if (0 == compare_string_no_case(type, "playlistInster")) {
+  } else if (0 == compare_string_no_case(type, "playlistInsert")) {
     LOGD() << "Action type: " << type << ". Add new playback.";
 
   } else if (0 == compare_string_no_case(type, "playlistRemove")) {


### PR DESCRIPTION
This is a significant typo.

I am using your c++ class ap_casting_media_store verbatim (with the hlsparse library) , through extern "C" wrappers to and from C, with http handlers in C that are functionally-equivalent to  your handlers, and an extern  "C" implementation  of send_fcup_request.

The first POST /action request I see after POST /play   is of Action type "playlistInsert"    not "unhandledURLResponse"

Unfortunately, your code tests the Action type against "playlistInster"   so misses it because of the typo (and I have no model to follow for implementing this action because it is unimplemented in your code).

* there are a number of  "cosmetic" other typos (hanlder for handler, meida for media , plus others) that I noticed.  Would you like a Pull Request to fix these?


* any suggestions on handling these unhandled action types playlistInsert and playlistRemove?

