### PR TITLE
protect against coredump when uri in linked list is NULL

### DIFF
--- a/src/service/ap_casting_media_data_store.cpp
+++ b/src/service/ap_casting_media_data_store.cpp
@@ -92,14 +92,14 @@ std::string ap_casting_media_data_store::process_media_data(const std::string &u
 
         // Save all media uri
         media_list_t *media_item = &master_playlist.media;
-        while (media_item && media_item->data) {
+        while (media_item && media_item->data && media_item->data->uri) {
           uri_stack_.push(media_item->data->uri);
           media_item = media_item->next;
         }
 
         // Save all stream uri
         stream_inf_list_t *stream_item = &master_playlist.stream_infs;
-        while (stream_item && stream_item->data) {
+        while (stream_item && stream_item->data && stream_item->data->uri) {
           uri_stack_.push(stream_item->data->uri);
           stream_item = stream_item->next;
         }


### PR DESCRIPTION
a null uri in the stream linked list caused coredump.   A null value probably will not occur in a working airplay video streaming implementation, but should be protected against.


"terminate called after throwing an instance of 'std::logic_error'... "

note:  the only apsdk-public code I am now working with is  the class ap_casting_media_data_store   (inside a C-wrapper, with hlsparse including your fixes to it).   I if come across any more issues in that class I will submit a PR. 

